### PR TITLE
Fix set_lastrun_config key/value swap

### DIFF
--- a/classes/util.php
+++ b/classes/util.php
@@ -257,7 +257,7 @@ class util {
      * @param string $type
      */
     final protected static function set_lastrun_config($type) {
-        set_config(time(), $type . '_lastrun', 'tool_usersuspension');
+        set_config($type . '_lastrun', time(), 'tool_usersuspension');
     }
 
     /**


### PR DESCRIPTION
Setting the config value for the `lastrun` variable with set_config had swapped key and value; resulting in a new plugin config setting for each scheduled task run.

`lib/moodlelib.php:function set_config($name, $value, $plugin=null)`

Fixes lastrun config and smart detection.