### PR TITLE
Fixed bug that prevented suspension warnings from being sent to users

### DIFF
--- a/classes/util.php
+++ b/classes/util.php
@@ -149,7 +149,7 @@ class util {
         if (!(bool)config::get('enablesmartdetect')) {
             return false;
         }
-        $lastrun = static::get_lastrun_config('smartdetect', 0, true);
+        $lastrun = static::get_lastrun_config('smartdetect', 0, false);
         $deltatime = time() - $lastrun;
         if ($deltatime < config::get('smartdetect_interval')) {
             return false;
@@ -176,11 +176,15 @@ class util {
         if (!(bool)config::get('enablesmartdetect')) {
             return false;
         }
+
+        // Always update lastrun if smartdetect is enabled. Lastrun is not updated in mark_users_to_suspend()
+        // so that the deltatime can be correctly calculated here.
+        $lastrun = static::get_lastrun_config('smartdetect', 0, true);
+
         if (!(bool)config::get('enablesmartdetect_warning')) {
             return false;
         }
         // Run in parallel with the suspensions.
-        $lastrun = static::get_lastrun_config('smartdetect', 0, true);
         $deltatime = time() - $lastrun;
         if ($deltatime < config::get('smartdetect_interval')) {
             return false;


### PR DESCRIPTION
When testing the email notification functionality of this plugin, we noticed that the messages to warn users ahead of their suspension (enabled with the `tool_usersuspension | enablesmartdetect_warning` config checkbox) were not being sent. A quick look at the code revealed a bug.

In the `suspend/mark.php` task, the `\tool_usersuspension\util::mark_users_to_suspend();` function is called first. In it, on line 152, `get_lastrun_config('smartdetect', 0, true);` gets called with it's `autosetnew` param set to true. This updates the lastrun timestamp for `smartdetect`. When the function finishes, `\tool_usersuspension\util::warn_users_of_suspension();` is called next, which again uses `get_lastrun_config('smartdetect', 0, true);` to calculate elapsed time since the last run, but the elapsed time will always be close to 0, since the lastrun timestamp was just updated in `mark_users_to_suspend();`.

The fix is simple - I changed `get_lastrun_config('smartdetect', 0, true);` in `\tool_usersuspension\util::mark_users_to_suspend();` to `get_lastrun_config('smartdetect', 0, false);` so the lastrun time is no longer updated too quickly. I then moved the `get_lastrun_config` call in `\tool_usersuspension\util::warn_users_of_suspension();` higher, above the `config::get('enablesmartdetect_warning')` check, so that it always updates the lastrun if `smartdetect` is enabled. It may be a better idea to get the lastrun timestamp in the `suspend/mark.php` task and pass it to both functions as an input parameter, however that would require a larger redesign.