### PR TITLE
Add username to string data

### DIFF
--- a/classes/util.php
+++ b/classes/util.php
@@ -598,6 +598,7 @@ class util {
         $a->name = fullname($user);
         $a->timeinactive = static::format_timespan(config::get('smartdetect_suspendafter'));
         $a->contact = $from->email;
+        $a->username = $user->username;
         $a->signature = fullname($from);
         $subject = get_string_manager()->get_string('email:user:suspend:subject',
                 'tool_usersuspension', $a, $user->lang);
@@ -626,6 +627,7 @@ class util {
         $a->suspendinterval = static::format_timespan(config::get('smartdetect_suspendafter'));
         $a->warningperiod = static::format_timespan(config::get('smartdetect_warninginterval'));
         $a->contact = $from->email;
+        $a->username = $user->username;
         $a->signature = fullname($from);
         $subject = get_string('email:user:warning:subject', 'tool_usersuspension', $a);
         $messagehtml = get_string('email:user:warning:body', 'tool_usersuspension', $a);
@@ -649,6 +651,7 @@ class util {
         $a = new \stdClass();
         $a->name = fullname($user);
         $a->contact = $from->email;
+        $a->username = $user->username;
         $a->signature = fullname($from);
         $subject = get_string_manager()->get_string('email:user:unsuspend:subject',
                 'tool_usersuspension', $a, $user->lang);
@@ -674,6 +677,7 @@ class util {
         $a->name = fullname($user);
         $a->timesuspended = static::format_timespan(config::get('cleanup_deleteafter'));
         $a->contact = $from->email;
+        $a->username = $user->username;
         $a->signature = fullname($from);
         $subject = get_string_manager()->get_string('email:user:delete:subject',
                 'tool_usersuspension', $a, $user->lang);


### PR DESCRIPTION
In Moodle, emails are not unique, but usernames are. So when a user receives a suspension or deletion mail, it can be confusing as to which account the mail belongs to, if said user has multiple accounts.

This PR adds `username` column data from the `$user` object to the string data object, so that admins that use this plugin can modify their local translation of the suspension/deletion email to include the username. It does not change the default translation, as I'm not sure, this would be desired default text.

Current default text (ex. `email:user:suspend:auto:body`):
```php
$string['email:user:suspend:auto:body'] = '<p>Dear {$a->name}</p>
<p>Your account has been suspended after {$a->timeinactive} of inactivity.</p>
<p>If you feel this is unintended or want to have your account activated again,
please contact {$a->contact}</p>
<p>Regards<br/>{$a->signature}</p>';
```
Our use-case local translation:
```php
$string['email:user:suspend:auto:body'] = '<p>Dear {$a->name}</p>
<p>Your account "{$a->username}" has been suspended after {$a->timeinactive} of inactivity.</p>
<p>If you feel this is unintended or want to have your account activated again,
please contact {$a->contact}</p>
<p>Regards<br/>{$a->signature}</p>';
```

Please let me know, if this PR is to be included, whether the default translation should also be changed, or remain as-is. Also, if there should be any additional email translation documentation added.